### PR TITLE
Make multiple doc_root case actually working

### DIFF
--- a/src/rebar3_erlydtl_plugin.erl
+++ b/src/rebar3_erlydtl_plugin.erl
@@ -120,6 +120,14 @@ init(State) ->
                                                                {opts, []}])),
     {ok, State1}.
 
+expand_opts(Opts) ->
+    SharedOpts = lists:filter(fun(X) -> is_tuple(X) end, Opts),
+    OptsLists  = case lists:filter(fun(X) -> is_list(X) end, Opts) of
+                   [] -> [[]];
+                   L  -> L
+                 end,
+    lists:map(fun(X) -> lists:ukeymerge(1, proplists:unfold(X), SharedOpts) end, OptsLists).
+
 do(State) ->
     rebar_api:info("Running erlydtl...", []),
     Apps = case rebar_state:current_app(State) of
@@ -133,24 +141,26 @@ do(State) ->
          Dir = rebar_app_info:dir(AppInfo),
          OutDir = rebar_app_info:ebin_dir(AppInfo),
 
-         DtlOpts = proplists:unfold(rebar_opts:get(Opts, erlydtl_opts, [])),
-         TemplateDir = filename:join(Dir, option(doc_root, DtlOpts)),
-         DtlOpts2 = [{doc_root, TemplateDir} | proplists:delete(doc_root, DtlOpts)],
-         TagDir = filename:join(Dir, option(custom_tags_dir, DtlOpts2)),
-         DtlOpts3 = [{custom_tags_dir, TagDir} | proplists:delete(custom_tags_dir, DtlOpts2)],
-         filelib:ensure_dir(filename:join(OutDir, "dummy.beam")),
+         DtlOpts1 = proplists:unfold(rebar_opts:get(Opts, erlydtl_opts, [])),
+         lists:foreach(fun(DtlOpts) ->
+             TemplateDir = filename:join(Dir, option(doc_root, DtlOpts)),
+             DtlOpts2 = [{doc_root, TemplateDir} | proplists:delete(doc_root, DtlOpts)],
+             TagDir = filename:join(Dir, option(custom_tags_dir, DtlOpts2)),
+             DtlOpts3 = [{custom_tags_dir, TagDir} | proplists:delete(custom_tags_dir, DtlOpts2)],
+             filelib:ensure_dir(filename:join(OutDir, "dummy.beam")),
 
-         rebar_base_compiler:run(Opts,
-                                 [],
-                                 TemplateDir,
-                                 option(source_ext, DtlOpts3),
-                                 OutDir,
-                                 option(module_ext, DtlOpts3) ++ ".beam",
-                                 fun(S, T, C) ->
-                                         compile_dtl(C, S, T, DtlOpts3, Dir, OutDir)
-                                 end,
-                                 [{check_last_mod, false},
-                                  {recursive, option(recursive, DtlOpts3)}])
+             rebar_base_compiler:run(Opts,
+                                     [],
+                                     TemplateDir,
+                                     option(source_ext, DtlOpts3),
+                                     OutDir,
+                                     option(module_ext, DtlOpts3) ++ ".beam",
+                                     fun(S, T, C) ->
+                                             compile_dtl(C, S, T, DtlOpts3, Dir, OutDir)
+                                     end,
+                                     [{check_last_mod, false},
+                                      {recursive, option(recursive, DtlOpts3)}])
+          end, expand_opts(DtlOpts1))
      end || AppInfo <- Apps],
 
     {ok, State}.


### PR DESCRIPTION
Using erlydtl_opts configuration with multiple doc_roots as in example mentioned in the docs:

> The following example will compile the following templates:
> "src/*.dtl" files into "ebin/*_dtl.beam" and
> "priv/templates/*.html" into "ebin/*.beam". Note that any tuple option
> (such as 'out_dir') in the outer list is added to each inner list:
>   {erlydtl_opts, [
>      {out_dir, "ebin"},
>      {recursive, false},
>      [
>          {doc_root, "src"}, {module_ext, "_dtl"}
>      ],
>      [
>          {doc_root, "priv/templates"}, {module_ext, ""}, {source_ext, ".html"}
>      ]
>   ]}.

results in uncaught error: badarg in lists:ukeymerge called at line 197 of rebar3_erlydtl_plugin.erl.

This patch solves that problem.

