### PR TITLE
Incl template location in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,5 @@ To have it invoked automatically when running `rebar3 compile` add it as a `prov
                  {pre, [{compile, {erlydtl, compile}}]}
                  ]}.
 ```
+
+Any templates in 'priv/templates' will then be compiled, by default, but this location is configurable.


### PR DESCRIPTION
I had to read the comment in the source file to find out where to put my templates, I think that's useful enough to live in the readme.